### PR TITLE
Performance: use fewer operations in generate sum loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Improvements
 
+- [TBD]() Improve prover performance by using an arithmetic sequence rather than interpolation inside of the `prove_round` loop.
+
 - [\#55](https://github.com/arkworks-rs/sumcheck/pull/55) Improve the interpolation performance and avoid unnecessary state clones.
 
 ### Bug fixes


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The following line is doing a lot of redundant compute for different iterations of t. 
```rust
product *= table[b << 1] * (F::one() - t_as_field)
                            + table[(b << 1) + 1] * t_as_field;
```
In fact, the two `*` on the rhs can be removed entirely. This PR instead replaces `table[b << 1] * (F::one() - t_as_field) + table[(b << 1) + 1] * t_as_field` with an arithmetic sequence with first term `table[b << 1]` and second term `table[(b << 1) + 1]`.

This improves performance by a decent amount. For instance:
```
Prove/GKR/15            time:   [75.101 ms 78.168 ms 81.418 ms]                         
                        change: [-48.075% -44.927% -41.822%] (p = 0.00 < 0.05)
                        Performance has improved.
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] ~Linked to Github issue with discussion and accepted design OR~ have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~ - This is simply a rewrite of a loop, no functionality has changed.
- [x] ~Updated relevant documentation in the code~ - Nothing to update
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer